### PR TITLE
Fix IntelliSense w/ PlatformIO IDE on Linux

### DIFF
--- a/src/knx/bits.h
+++ b/src/knx/bits.h
@@ -4,10 +4,9 @@
 #include <cstdint>
 
 #if defined(__linux__)
-#include <arpa/inet.h>
 #elif defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_ARCH_STM32) || defined (DeviceFamily_CC13X0)
 #define getbyte(x,n) (*(((uint8_t*)&(x))+n))
-#define htons(x)  ( (getbyte(x,0)<<8) | getbyte(x,1) ) 
+#define htons(x)  ( (getbyte(x,0)<<8) | getbyte(x,1) )
 #define htonl(x) ( (getbyte(x,0)<<24) | (getbyte(x,1)<<16) | (getbyte(x,2)<<8) | getbyte(x,3) )
 #define ntohs(x) htons(x)
 #define ntohl(x) htonl(x)


### PR DESCRIPTION
IntelliSense was broken in VS Code w/ the PlatformIO IDE plugin on Linux. This PR fixes this (including `inet.h` from `knx/bits.h` seems to be superfluous and removing the include solves the IntelliSense issues).