### PR TITLE
fix: prevent use of uninitialized _savedAsapXXX variables (#241)

### DIFF
--- a/src/knx/application_layer.cpp
+++ b/src/knx/application_layer.cpp
@@ -82,13 +82,25 @@ void ApplicationLayer::dataGroupConfirm(AckType ack, HopCountType hopType, Prior
     switch (apdu.type())
     {
     case GroupValueRead:
-        _bau.groupValueReadLocalConfirm(ack, _savedAsapReadRequest, priority, hopType, secCtrl, status);
+        if (_savedAsapReadRequest > 0)
+            _bau.groupValueReadLocalConfirm(ack, _savedAsapReadRequest, priority, hopType, secCtrl, status);
+        else 
+            println("dataGroupConfirm: APDU-Type GroupValueRead has _savedAsapReadRequest = 0");
+        _savedAsapReadRequest = 0;
         break;
     case GroupValueResponse:
-        _bau.groupValueReadResponseConfirm(ack, _savedAsapResponse, priority, hopType, secCtrl, apdu.data(), apdu.length() - 1, status);
+        if (_savedAsapResponse > 0)
+            _bau.groupValueReadResponseConfirm(ack, _savedAsapResponse, priority, hopType, secCtrl, apdu.data(), apdu.length() - 1, status);
+        else 
+            println("dataGroupConfirm: APDU-Type GroupValueResponse has _savedAsapResponse = 0");
+        _savedAsapResponse = 0;
         break;
     case GroupValueWrite:
-        _bau.groupValueWriteLocalConfirm(ack, _savedAsapWriteRequest, priority, hopType, secCtrl, apdu.data(), apdu.length() - 1, status);
+        if (_savedAsapWriteRequest > 0)
+            _bau.groupValueWriteLocalConfirm(ack, _savedAsapWriteRequest, priority, hopType, secCtrl, apdu.data(), apdu.length() - 1, status);
+        else 
+            println("dataGroupConfirm: APDU-Type GroupValueWrite has _savedAsapWriteRequest = 0");
+        _savedAsapWriteRequest = 0;
         break;
     default:
         print("datagroup-confirm: unhandled APDU-Type: ");

--- a/src/knx/application_layer.h
+++ b/src/knx/application_layer.h
@@ -202,9 +202,9 @@ class ApplicationLayer
     void individualConfirm(AckType ack, HopCountType hopType, Priority priority, uint16_t tsap, APDU& apdu, const SecurityControl& secCtrl, bool status);
     void individualSend(AckType ack, HopCountType hopType, Priority priority, uint16_t asap, APDU& apdu, const SecurityControl& secCtrl);
 
-    uint16_t _savedAsapReadRequest;
-    uint16_t _savedAsapWriteRequest;
-    uint16_t _savedAsapResponse;
+    uint16_t _savedAsapReadRequest = 0;
+    uint16_t _savedAsapWriteRequest = 0;
+    uint16_t _savedAsapResponse = 0;
     AssociationTableObject* _assocTable = nullptr;
     BusAccessUnit& _bau;
 


### PR DESCRIPTION
- src/knx/application_layer.h: Initialize _savedAsapXXX
- src/knx/application_layer.cpp: prevent xxxConfirm-Calls if _savedAsapXXX values are 0