### PR TITLE
fixed wrong answers to property read:

### DIFF
--- a/src/knx/data_property.cpp
+++ b/src/knx/data_property.cpp
@@ -5,14 +5,15 @@
 
 uint8_t DataProperty::read(uint16_t start, uint8_t count, uint8_t* data) const
 {
-    if (count == 0 || _currentElements == 0 || start > _currentElements || count > _currentElements - start + 1)
-        return 0;
-
     if (start == 0)
     {
         pushWord(_currentElements, data);
         return 1;
     }
+
+    if (count == 0 || _currentElements == 0 || start > _currentElements || count > _currentElements - start + 1)
+        return 0;
+
 
     // we start counting with zero
     start -= 1;


### PR DESCRIPTION
with start = 0 (read the number of current elements) and current elements = 0 (empty property) 0 was returned which results in an error message when reading this property.