### PR TITLE
Sub Group "0" and Typo Fix

### DIFF
--- a/src/knx/dpt.cpp
+++ b/src/knx/dpt.cpp
@@ -8,8 +8,9 @@ Dpt::Dpt()
 Dpt::Dpt(short mainGroup, short subGroup, short index /* = 0 */)
     : mainGroup(mainGroup), subGroup(subGroup), index(index)
 {
-    if (subGroup == 0)
-        println("WARNING: You used and invalid Dpt *.0");
+    if ((mainGroup < 14 || mainGroup > 16) &&
+        subGroup == 0)
+        println("WARNING: You used an invalid Dpt *.0");
 }
 
 bool Dpt::operator==(const Dpt& other) const


### PR DESCRIPTION
- Fixed sub group "0" should not trigger a warning for DPTs 14-16.
- Fixed typing mistake in warning.