### PR TITLE
Update TPUart dependency to version 1.0.5

### DIFF
--- a/library.json
+++ b/library.json
@@ -19,6 +19,6 @@
         "url": "https://github.com/OpenKNX/knx"
     },
     "dependencies": {
-        "TPUart": "https://github.com/OpenKNX/tpuart#1.0.4"
+        "TPUart": "https://github.com/OpenKNX/tpuart#1.0.5"
     }
 }


### PR DESCRIPTION
TPUart: New in 1.0.5 - Add SOC_UART_HP_NUM check before initializing UART2 task (prevents runtime/build errors on esp targets without UART2)