### PR TITLE
Hotfix/wrong handling dpt16 datalength

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ See the examples for basic usage options
 
 ## Changelog
 
+### v2.3.1 - 2026-03-04
+
+- Hotfix: DPT16 was not correctly handled for uninitialized KOs
+
 ### v2.3.0 - 2026-01-28
 - Fix Define for 'DPT_FlowRate_m3/h'
 - Enhance multicast initialization logging

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "knx",
-    "version": "2.2.2",
+    "version": "2.3.1",
     "description": "knx stack",
     "homepage": "https://openknx.de",
     "authors": [

--- a/src/knx/dpt.cpp
+++ b/src/knx/dpt.cpp
@@ -22,7 +22,7 @@ bool Dpt::operator!=(const Dpt& other) const
     return !(other == *this);
 }
 
-unsigned char Dpt::sizeInMemory() const
+unsigned char Dpt::dataLength() const
 {
     switch (mainGroup)
     {

--- a/src/knx/dpt.cpp
+++ b/src/knx/dpt.cpp
@@ -72,7 +72,7 @@ unsigned char Dpt::sizeInMemory() const
         case 275:
             return 8;
         case 16:
-            return 15; // terminating with 0x00 char
+            return 14; 
         case 285:
             return 16;
         default:

--- a/src/knx/dpt.h
+++ b/src/knx/dpt.h
@@ -370,5 +370,5 @@ class Dpt
     unsigned short index;
     bool operator==(const Dpt& other) const;
     bool operator!=(const Dpt& other) const;
-    unsigned char sizeInMemory() const;
+    unsigned char dataLength() const;
 };

--- a/src/knx/group_object.cpp
+++ b/src/knx/group_object.cpp
@@ -293,8 +293,9 @@ void GroupObject::recalculateDataLength(const Dpt& type)
         _dataLength = sizeInMemory;
         if (_data)
             delete[] _data;
-        _data = new uint8_t[_dataLength];
-        memset(_data, 0, _dataLength);
+        if (type.mainGroup == 16) sizeInMemory++;
+        _data = new uint8_t[sizeInMemory];
+        memset(_data, 0, sizeInMemory);
     }
 }
 

--- a/src/knx/group_object.cpp
+++ b/src/knx/group_object.cpp
@@ -287,13 +287,13 @@ bool GroupObject::valueNoSend(const KNXValue& value)
 
 void GroupObject::recalculateDataLength(const Dpt& type)
 {
-    uint8_t sizeInMemory = type.sizeInMemory();
-    if (_commFlagEx.uninitialized && sizeInMemory > _dataLength)
+    uint8_t dataLength = type.dataLength();
+    if (_commFlagEx.uninitialized && dataLength > _dataLength)
     {
-        _dataLength = sizeInMemory;
+        _dataLength = dataLength;
         if (_data)
             delete[] _data;
-        if (type.mainGroup == 16) sizeInMemory++;
+        uint8_t sizeInMemory = (type.mainGroup == 16) ? dataLength + 1 : dataLength;
         _data = new uint8_t[sizeInMemory];
         memset(_data, 0, sizeInMemory);
     }


### PR DESCRIPTION
We need this to correct dpt16 handling, the original error was a misunderstanding, that data length an length in memory mean the same.
Rest of the change is just renaming. 
This is ment as a hotfix for v1 and v1dev.
changelog and version are also updated.

Regards,
Waldemar

P.S.: Version was not set to 2.3.0 even though chnagelog stated a version 2.3.0. I updated both to 2.3.1.